### PR TITLE
set `#![no_std]`

### DIFF
--- a/serde_unit_struct/src/lib.rs
+++ b/serde_unit_struct/src/lib.rs
@@ -9,6 +9,8 @@
 //! struct Foo;
 //! ```
 
+#![no_std]
+
 pub use serde_unit_struct_derive::{Deserialize_unit_struct, Serialize_unit_struct};
 
 #[cfg(test)]

--- a/serde_unit_struct_derive/src/lib.rs
+++ b/serde_unit_struct_derive/src/lib.rs
@@ -43,9 +43,9 @@ pub fn deserialize_derive(input: TokenStream) -> TokenStream {
     let deserialize_impl = quote! {
         impl<'de> serde::Deserialize<'de> for #name {
             fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-                <String as serde::Deserialize>::deserialize(deserializer)
+                <&str as serde::Deserialize>::deserialize(deserializer)
                     .and_then(|s| {
-                        if &s == #name_str {
+                        if s == #name_str {
                             Ok(Self)
                         } else {
                             Err(serde::de::Error::custom(#error_msg))


### PR DESCRIPTION
I don't see a reason not to, and then this crate will work on embedded projects :)